### PR TITLE
Precise translation for the Trash emptying button

### DIFF
--- a/locales/es/es.json
+++ b/locales/es/es.json
@@ -2,7 +2,7 @@
 	"cloudDrive": "Cloud Drive",
 	"new": "Nuevo",
 	"image": "Imagen",
-	"empty": "Vacío",
+	"emptyTrash": "Vaciar",
 	"copiedToClipboard": "Copiado al portapapeles",
 	"everyone": "Todos",
 	"unknownUser": "Usuario desconocido",

--- a/src/components/mainContainer/topBar/index.tsx
+++ b/src/components/mainContainer/topBar/index.tsx
@@ -179,7 +179,7 @@ export const TopBar = memo(() => {
 						ref={emptyTrashBtnRef}
 						onClick={emptyTrash}
 					>
-						{t("empty")}
+						{t("emptyTrash")}
 					</Button>
 				) : (
 					<DropdownMenu>


### PR DESCRIPTION
The Trash emptying button used the string "Vacío" which is the Spanish adjective to represent "empty" as a state:
<img width="1261" height="119" alt="image" src="https://github.com/user-attachments/assets/ac28ad8f-a36d-4a2c-a41b-a4516d309741" />

However, the button triggers an action, so the infinitive verb must be put, which is "Vaciar".
<img width="1261" height="119" alt="image" src="https://github.com/user-attachments/assets/f8a3ddfa-ef1d-446f-9829-c3e66818d0fa" />

I not only renamed the value in _locales/es/es.json_ but also changed the key to "emptyTrash" for more clarity.

I have tested the changes locally.

If you're happy with this PR, feel free to count on me for Spanish translations in the future.
