### PR TITLE
Fix video thumbnail generation

### DIFF
--- a/src/lib/worker/worker.ts
+++ b/src/lib/worker/worker.ts
@@ -1979,12 +1979,10 @@ export async function generateVideoThumbnail({ item }: { item: DriveCloudItem })
 					return
 				}
 
-				setTimeout(() => {
-					video.currentTime = video.duration >= 3 ? 3 : 1
-				}, 100)
+				video.currentTime = video.duration >= 3 ? 3 : 1
 			}
 
-			video.onseeked = () => {
+			video.requestVideoFrameCallback(() => {
 				const originalWidth = video.videoWidth
 				const originalHeight = video.videoHeight
 				const thumbnailWidth = THUMBNAIL_MAX_SIZE
@@ -2017,7 +2015,6 @@ export async function generateVideoThumbnail({ item }: { item: DriveCloudItem })
 					return
 				}
 
-				ctx.clearRect(0, 0, thumbnailWidth, thumbnailHeight)
 				ctx.fillStyle = "black"
 				ctx.fillRect(0, 0, thumbnailWidth, thumbnailHeight)
 				ctx.drawImage(video, offsetX, offsetY, drawWidth, drawHeight, 0, 0, thumbnailWidth, thumbnailHeight)
@@ -2034,7 +2031,7 @@ export async function generateVideoThumbnail({ item }: { item: DriveCloudItem })
 					"image/jpeg",
 					THUMBNAIL_QUALITY
 				)
-			}
+			})
 
 			video.load()
 		})


### PR DESCRIPTION
Video files sometimes have broken thumbnails since ```video.onseeked``` does not wait for the new frame to be ready, it only waits for the video seek. ```video.requestVideoFrameCallback``` fixes this.