### PR TITLE
Support for HEIC/HEIF images

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
 			http-equiv="Content-Security-Policy"
 			content="
 				default-src 'self';
-				script-src 'self' https://analytics.filen.io 'sha256-/AO8vAagk08SqUGxY96ci/dGyTDsuoetPOJYMn7sc+E=';
+				script-src 'self' https://analytics.filen.io 'sha256-/AO8vAagk08SqUGxY96ci/dGyTDsuoetPOJYMn7sc+E=' 'wasm-unsafe-eval';
 				style-src 'self' 'unsafe-inline';
 				img-src 'self' data: blob: http://localhost:* https://egest.filen.io https://down.filen.io https://egest.filen.net https://egest.filen-1.net https://egest.filen-2.net https://egest.filen-3.net https://egest.filen-4.net https://egest.filen-5.net https://egest.filen-6.net;
 				font-src 'self';

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
 				"i18next-http-backend": "^2.5.0",
 				"input-otp": "^1.1.0",
 				"js-cookie": "^3.0.5",
+				"libheif-js": "^1.19.8",
 				"localforage": "^1.10.0",
 				"localforage-memoryStorageDriver": "^0.9.2",
 				"lodash": "^4.17.21",
@@ -13531,6 +13532,14 @@
 			},
 			"engines": {
 				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/libheif-js": {
+			"version": "1.19.8",
+			"resolved": "https://registry.npmjs.org/libheif-js/-/libheif-js-1.19.8.tgz",
+			"integrity": "sha512-vQJWusIxO7wavpON1dusciL8Go9jsIQ+EUrckauFYAiSTjcmLAsuJh3SszLpvkwPci3JcL41ek2n+LUZGFpPIQ==",
+			"engines": {
+				"node": ">=8.0.0"
 			}
 		},
 		"node_modules/lie": {

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
 		"i18next-http-backend": "^2.5.0",
 		"input-otp": "^1.1.0",
 		"js-cookie": "^3.0.5",
+		"libheif-js": "^1.19.8",
 		"localforage": "^1.10.0",
 		"localforage-memoryStorageDriver": "^0.9.2",
 		"lodash": "^4.17.21",

--- a/src/components/dialogs/previewDialog/index.tsx
+++ b/src/components/dialogs/previewDialog/index.tsx
@@ -3,6 +3,7 @@ import { Dialog, DialogContent } from "@/components/ui/dialog"
 import eventEmitter from "@/lib/eventEmitter"
 import { type DriveCloudItem } from "@/components/drive"
 import { fileNameToPreviewType, ensureTextFileExtension, isFileStreamable } from "./utils"
+import { isHEIC } from "@/lib/heic"
 import Text from "./text"
 import PDF from "./pdf"
 import Image from "./image"
@@ -343,7 +344,7 @@ export const PreviewDialog = memo(() => {
 					return
 				}
 
-				const buffer = await readFileAndSanitize({
+				let buffer = await readFileAndSanitize({
 					item: itm,
 					emitEvents: false
 				})
@@ -354,9 +355,18 @@ export const PreviewDialog = memo(() => {
 						[itm.uuid]: buffer
 					}))
 				} else {
+					let mimeType = itm.mime
+
+					if (isHEIC(itm.name)) {
+						const { convertHEICToJPEG } = await import("@/lib/heic")
+
+						buffer = await convertHEICToJPEG(buffer)
+						mimeType = "image/jpeg"
+					}
+
 					setURLObjects(prev => ({
 						...prev,
-						[itm.uuid]: globalThis.URL.createObjectURL(new Blob([buffer], { type: itm.mime }))
+						[itm.uuid]: globalThis.URL.createObjectURL(new Blob([buffer], { type: mimeType }))
 					}))
 				}
 			} catch (e) {

--- a/src/components/dialogs/previewDialog/utils.ts
+++ b/src/components/dialogs/previewDialog/utils.ts
@@ -21,7 +21,9 @@ export function fileNameToPreviewType(name: string) {
 		case ".jpg":
 		case ".jpeg":
 		case ".webp":
-		case ".svg": {
+		case ".svg":
+		case ".heic":
+		case ".heif": {
 			return "image"
 		}
 
@@ -124,7 +126,9 @@ export function fileNameToThumbnailType(name: string) {
 		case ".png":
 		case ".jpg":
 		case ".webp":
-		case ".jpeg": {
+		case ".jpeg":
+		case ".heic":
+		case ".heif": {
 			return "image"
 		}
 

--- a/src/lib/heic.ts
+++ b/src/lib/heic.ts
@@ -1,0 +1,79 @@
+// libheif-bundle.mjs is an ESM file with WASM inlined as base64 — no CJS, no require(),
+// no external .wasm fetch. We import it directly to avoid Vite's pre-bundler touching
+// the 1.4 MB compiled bundle (which breaks with esbuild's CJS transformer).
+import createLibheif from "libheif-js/libheif-wasm/libheif-bundle.mjs"
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type LibHeif = any
+
+let libheifInstance: LibHeif | null = null
+
+async function getLibheif(): Promise<LibHeif> {
+	if (libheifInstance) {
+		return libheifInstance
+	}
+
+	const lib = createLibheif()
+
+	await lib.ready
+
+	libheifInstance = lib
+
+	return lib
+}
+
+export async function convertHEICToJPEG(buffer: Buffer): Promise<Buffer> {
+	const libheif = await getLibheif()
+	const decoder = new libheif.HeifDecoder()
+	const images: LibHeif[] = decoder.decode(new Uint8Array(buffer))
+
+	if (!images.length) {
+		throw new Error("HEIC image not found")
+	}
+
+	let result: { width: number; height: number; data: Uint8ClampedArray }
+
+	try {
+		const image = images[0]
+		const width: number = image.get_width()
+		const height: number = image.get_height()
+
+		result = await new Promise((resolve, reject) => {
+			image.display({ data: new Uint8ClampedArray(width * height * 4), width, height }, (displayData: { data: Uint8ClampedArray } | null) => {
+				if (!displayData) {
+					reject(new Error("HEIC display error"))
+
+					return
+				}
+
+				resolve({ width, height, data: displayData.data })
+			})
+		})
+	} finally {
+		for (const image of images) {
+			image.free()
+		}
+
+		decoder.decoder.delete()
+	}
+
+	const { width, height, data } = result
+	const canvas = new OffscreenCanvas(width, height)
+	const ctx = canvas.getContext("2d")
+
+	if (!ctx) {
+		throw new Error("Could not get OffscreenCanvas context")
+	}
+
+	ctx.putImageData(new ImageData(data, width, height), 0, 0)
+
+	const blob = await canvas.convertToBlob({ type: "image/jpeg", quality: 0.9 })
+
+	return Buffer.from(await blob.arrayBuffer())
+}
+
+export function isHEIC(name: string): boolean {
+	const lower = name.toLowerCase()
+
+	return lower.endsWith(".heic") || lower.endsWith(".heif")
+}

--- a/src/lib/libheif.d.ts
+++ b/src/lib/libheif.d.ts
@@ -1,0 +1,5 @@
+declare module "libheif-js/libheif-wasm/libheif-bundle.mjs" {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	const createLibheif: (options?: Record<string, unknown>) => any
+	export default createLibheif
+}

--- a/src/lib/worker/worker.ts
+++ b/src/lib/worker/worker.ts
@@ -1847,7 +1847,16 @@ export async function generateImageThumbnail({ item }: { item: DriveCloudItem })
 	}
 
 	const buffer = await readFile({ item, emitEvents: false })
-	const imageBitmap = await createImageBitmap(new Blob([buffer], { type: item.mime }))
+	let imageBlob = new Blob([buffer], { type: item.mime })
+
+	if (item.name.toLowerCase().endsWith(".heic") || item.name.toLowerCase().endsWith(".heif")) {
+		const { convertHEICToJPEG } = await import("../heic")
+		const converted = await convertHEICToJPEG(buffer)
+
+		imageBlob = new Blob([converted], { type: "image/jpeg" })
+	}
+
+	const imageBitmap = await createImageBitmap(imageBlob)
 	const originalWidth = imageBitmap.width
 	const originalHeight = imageBitmap.height
 	let thumbnailWidth = originalWidth

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -142,6 +142,9 @@ export default defineConfig({
 			comlink()
 		]
 	},
+	optimizeDeps: {
+		exclude: ["libheif-js"]
+	},
 	build: {
 		sourcemap: true,
 		rollupOptions: {


### PR DESCRIPTION
I've added thumbnail and preview support for HEIC/HEIF images. Your Apple device photos will now show up properly in the overview and can be previewed without any workarounds.

### **Before**

<img width="731" height="431" alt="before" src="https://github.com/user-attachments/assets/443d0989-2737-471d-bcaa-fbd13d9b31b4" />


### **After**

**Thumbnail**
<img width="752" height="448" alt="aftert-thumb" src="https://github.com/user-attachments/assets/ac8312c6-df9b-40bc-9415-69ec32b03d46" />

**Preview**
<img width="1511" height="894" alt="after-preview" src="https://github.com/user-attachments/assets/c6b1cd21-f61d-459f-a09d-76619b9e72ae" />

Let me know if you run into anything or have feedback!